### PR TITLE
Fixed Automata Getting Stuck on top of blocks

### DIFF
--- a/src/main/resources/Server/Models/Intelligent/Kweebec/Kweebec_Clay.json
+++ b/src/main/resources/Server/Models/Intelligent/Kweebec/Kweebec_Clay.json
@@ -2,18 +2,18 @@
   "Parent": "Player",
   "Model": "NPC/Intelligent/Kweebec_Clay/Models/Model.blockymodel",
   "Texture": "NPC/Intelligent/Kweebec_Clay/Models/Texture.png",
-  "EyeHeight": 0.3,
-  "CrouchOffset": -0.05,
+  "EyeHeight": 0.5,
+  "CrouchOffset": 0,
   "HitBox": {
     "Max": {
-      "X": 0.25,
-      "Y": 0.5,
-      "Z": 0.25
+      "X": 0.13,
+      "Y": 0.62,
+      "Z": 0.13
     },
     "Min": {
-      "X": -0.25,
+      "X": -0.13,
       "Y": 0,
-      "Z": -0.25
+      "Z": -0.13
     }
   },
   "MinScale": 0.8,

--- a/src/main/resources/Server/Models/Intelligent/Trork/Trork_Clay.json
+++ b/src/main/resources/Server/Models/Intelligent/Trork/Trork_Clay.json
@@ -3,17 +3,17 @@
   "Model": "NPC/Intelligent/Trork_Clay/Models/Model.blockymodel",
   "Texture": "NPC/Intelligent/Trork_Clay/Models/Texture.png",
   "EyeHeight": 0.8,
-  "CrouchOffset": -0.1,
+  "CrouchOffset": 0,
   "HitBox": {
     "Max": {
-      "X": 0.5,
-      "Y": 0.9,
-      "Z": 0.5
+      "X": 0.3,
+      "Y": 1,
+      "Z": 0.3
     },
     "Min": {
-      "X": -0.25,
+      "X": -0.3,
       "Y": 0,
-      "Z": -0.25
+      "Z": -0.3
     }
   },
   "MinScale": 1,


### PR DESCRIPTION
Hitboxes for the automata were way off, this was causing them to get stuck overhanging blocks when they should have fallen down and been able to complete the action.

Readjusting the hitboxes fixed this and they will now happily climb over blocks to reach their target.
Closes #33
