### PR TITLE
Fixed Take Animation Running Constantly Sometimes

### DIFF
--- a/src/main/java/com/clayfactoria/codecs/task/DepositTaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/DepositTaskExecutor.java
@@ -1,15 +1,10 @@
 package com.clayfactoria.codecs.task;
 
-import static com.clayfactoria.utils.TaskHelper.getHeldItemstack;
-import static com.clayfactoria.utils.TaskHelper.getNPCEntity;
-
 import com.clayfactoria.codecs.Job;
-import com.clayfactoria.codecs.Task;
 import com.clayfactoria.components.JobComponent;
 import com.clayfactoria.utils.ContainerSlot;
 import com.clayfactoria.utils.TaskHelper;
 import com.hypixel.hytale.component.Component;
-import com.hypixel.hytale.component.ComponentType;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.logger.HytaleLogger;
@@ -18,80 +13,77 @@ import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
 import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.npc.entities.NPCEntity;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.clayfactoria.utils.TaskHelper.getHeldItemstack;
+import static com.clayfactoria.utils.TaskHelper.getNPCEntity;
+
 public class DepositTaskExecutor extends PointTaskExecutor {
 
-  private static final HytaleLogger LOGGER = HytaleLogger.forEnclosingClass();
+    private static final HytaleLogger LOGGER = HytaleLogger.forEnclosingClass();
 
-  @Override
-  public boolean canPerformTask(Ref<EntityStore> entityRef) {
-    Store<EntityStore> store = entityRef.getStore();
+    @Override
+    public boolean canPerformTask(Ref<EntityStore> ref) {
+        Store<EntityStore> store = ref.getStore();
+        Component<ChunkStore> blockEntity = TaskHelper.getBlockEntity(ref);
+        if (blockEntity == null) {
+            return false;
+        }
 
-    ComponentType<EntityStore, NPCEntity> component = NPCEntity.getComponentType();
-    Objects.requireNonNull(component, "NPC Entity Component Type was null");
+        ItemStack heldItemStack = getHeldItemstack(store, ref);
 
-    NPCEntity npcEntity = store.getComponent(entityRef, component);
-    Objects.requireNonNull(npcEntity, "NPC Entity was null");
+        ItemContainer inputContainer =
+            TaskHelper.getItemContainerFromComponent(blockEntity, ContainerSlot.Input);
+        Objects.requireNonNull(inputContainer, "Unexpected null input ItemContainer");
 
-    Component<ChunkStore> nearbyPOI = TaskHelper.findNearbyPOI(npcEntity, Task.DEPOSIT);
-    if (nearbyPOI == null) {
-      return false;
+        ItemContainer fuelContainer =
+            TaskHelper.getItemContainerFromComponent(blockEntity, ContainerSlot.Fuel);
+        Objects.requireNonNull(fuelContainer, "Unexpected null fuel ItemContainer");
+
+        // There must be space in the container for the item stack, and there must be space in hands
+        return heldItemStack == null
+            || fuelContainer.canAddItemStack(heldItemStack)
+            || inputContainer.canAddItemStack(heldItemStack);
     }
 
-    ItemStack heldItemStack = getHeldItemstack(store, entityRef);
+    @Override
+    public boolean execute(Ref<EntityStore> entityRef) {
 
-    ItemContainer inputContainer =
-        TaskHelper.getItemContainerFromComponent(nearbyPOI, ContainerSlot.Input);
-    Objects.requireNonNull(inputContainer, "Unexpected null input ItemContainer");
+        NPCEntity npcEntity = getNPCEntity(entityRef);
+        Store<EntityStore> store = entityRef.getStore();
+        JobComponent jobComponent = Objects.requireNonNull(
+            store.getComponent(entityRef, JobComponent.getComponentType()));
+        Job currentJob = Objects.requireNonNull(jobComponent.getCurrentJob());
 
-    ItemContainer fuelContainer =
-        TaskHelper.getItemContainerFromComponent(nearbyPOI, ContainerSlot.Fuel);
-    Objects.requireNonNull(fuelContainer, "Unexpected null fuel ItemContainer");
+        List<String> hotbarItems = TaskHelper.getHotbarItems(npcEntity.getRole());
 
-    // There must be space in the container for the item stack, and there must be space in hands
-    return heldItemStack == null
-        || fuelContainer.canAddItemStack(heldItemStack)
-        || inputContainer.canAddItemStack(heldItemStack);
-  }
-
-  @Override
-  public boolean execute(Ref<EntityStore> entityRef) {
-
-    NPCEntity npcEntity = getNPCEntity(entityRef);
-    Store<EntityStore> store = entityRef.getStore();
-    JobComponent jobComponent = Objects.requireNonNull(
-        store.getComponent(entityRef, JobComponent.getComponentType()));
-    Job currentJob = Objects.requireNonNull(jobComponent.getCurrentJob());
-
-    List<String> hotbarItems = TaskHelper.getHotbarItems(npcEntity.getRole());
-
-    // Attempt to deposit as fuel first (if this is a station with a fuel slot)
-    if (deposit(ContainerSlot.Fuel, npcEntity, currentJob, hotbarItems)) {
-      return true;
-    } else {
-      return deposit(ContainerSlot.Input, npcEntity, currentJob, hotbarItems);
+        // Attempt to deposit as fuel first (if this is a station with a fuel slot)
+        if (deposit(ContainerSlot.Fuel, npcEntity, currentJob, hotbarItems)) {
+            return true;
+        } else {
+            return deposit(ContainerSlot.Input, npcEntity, currentJob, hotbarItems);
+        }
     }
-  }
 
-  private boolean deposit(ContainerSlot containerSlot, NPCEntity npcEntity, Job currentJob,
-      List<String> hotbarItems) {
-    Store<EntityStore> store = Objects.requireNonNull(npcEntity.getReference()).getStore();
-    ItemContainer itemContainer = TaskHelper.getItemContainerAtPos(
-        Objects.requireNonNull(npcEntity.getWorld()),
-        currentJob.getLocation(),
-        containerSlot);
-    Objects.requireNonNull(itemContainer);
+    private boolean deposit(ContainerSlot containerSlot, NPCEntity npcEntity, Job currentJob,
+                            List<String> hotbarItems) {
+        Store<EntityStore> store = Objects.requireNonNull(npcEntity.getReference()).getStore();
+        ItemContainer itemContainer = TaskHelper.getItemContainerAtPos(
+            Objects.requireNonNull(npcEntity.getWorld()),
+            currentJob.getLocation(),
+            containerSlot);
+        Objects.requireNonNull(itemContainer);
 
-    ItemContainer npcInventory = TaskHelper.getNPCInventory(npcEntity, store);
-    AtomicBoolean fail = new AtomicBoolean(false);
-    npcInventory.forEach((slot, itemStack) -> {
-      if (!hotbarItems.contains(itemStack.getItemId())) {
-        fail.set(!TaskHelper.transferItem(npcInventory, itemContainer, slot));
-      }
-    });
-    return !fail.get();
-  }
+        ItemContainer npcInventory = TaskHelper.getNPCInventory(npcEntity, store);
+        AtomicBoolean fail = new AtomicBoolean(false);
+        npcInventory.forEach((slot, itemStack) -> {
+            if (!hotbarItems.contains(itemStack.getItemId())) {
+                fail.set(!TaskHelper.transferItem(npcInventory, itemContainer, slot));
+            }
+        });
+        return !fail.get();
+    }
 }

--- a/src/main/java/com/clayfactoria/codecs/task/DepositTaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/DepositTaskExecutor.java
@@ -4,21 +4,19 @@ import com.clayfactoria.codecs.Job;
 import com.clayfactoria.components.JobComponent;
 import com.clayfactoria.utils.ContainerSlot;
 import com.clayfactoria.utils.TaskHelper;
-import com.hypixel.hytale.component.Component;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.logger.HytaleLogger;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
-import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.npc.entities.NPCEntity;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.clayfactoria.utils.TaskHelper.getHeldItemstack;
 import static com.clayfactoria.utils.TaskHelper.getNPCEntity;
 
 public class DepositTaskExecutor extends PointTaskExecutor {
@@ -28,30 +26,21 @@ public class DepositTaskExecutor extends PointTaskExecutor {
     @Override
     public boolean canPerformTask(Ref<EntityStore> ref) {
         Store<EntityStore> store = ref.getStore();
-        Component<ChunkStore> blockEntity = TaskHelper.getBlockEntity(ref);
-        if (blockEntity == null) {
-            return false;
-        }
+        NPCEntity npc = getNPCEntity(ref);
+        List<String> hotbarItems = TaskHelper.getHotbarItems(npc.getRole());
 
-        ItemStack heldItemStack = getHeldItemstack(store, ref);
-
-        ItemContainer inputContainer =
-            TaskHelper.getItemContainerFromComponent(blockEntity, ContainerSlot.Input);
-        Objects.requireNonNull(inputContainer, "Unexpected null input ItemContainer");
-
-        ItemContainer fuelContainer =
-            TaskHelper.getItemContainerFromComponent(blockEntity, ContainerSlot.Fuel);
-        Objects.requireNonNull(fuelContainer, "Unexpected null fuel ItemContainer");
+        JobComponent jobComponent = store.getComponent(ref, JobComponent.getComponentType());
+        assert jobComponent != null;
+        Job job = jobComponent.getCurrentJob();
+        assert job != null;
 
         // There must be space in the container for the item stack, and there must be space in hands
-        return heldItemStack == null
-            || fuelContainer.canAddItemStack(heldItemStack)
-            || inputContainer.canAddItemStack(heldItemStack);
+        return canDeposit(ContainerSlot.Input, npc, job, hotbarItems)
+            || canDeposit(ContainerSlot.Fuel, npc, job, hotbarItems);
     }
 
     @Override
     public boolean execute(Ref<EntityStore> entityRef) {
-
         NPCEntity npcEntity = getNPCEntity(entityRef);
         Store<EntityStore> store = entityRef.getStore();
         JobComponent jobComponent = Objects.requireNonNull(
@@ -85,5 +74,24 @@ public class DepositTaskExecutor extends PointTaskExecutor {
             }
         });
         return !fail.get();
+    }
+
+    private boolean canDeposit(ContainerSlot containerSlot, NPCEntity npcEntity, Job currentJob,
+                               List<String> hotbarItems) {
+        Store<EntityStore> store = Objects.requireNonNull(npcEntity.getReference()).getStore();
+        ItemContainer itemContainer = TaskHelper.getItemContainerAtPos(
+            Objects.requireNonNull(npcEntity.getWorld()),
+            currentJob.getLocation(),
+            containerSlot);
+        Objects.requireNonNull(itemContainer);
+
+        ItemContainer npcInventory = TaskHelper.getNPCInventory(npcEntity, store);
+        List<ItemStack> itemStacks = new ArrayList<>();
+        npcInventory.forEach((_, itemStack) -> {
+            if (!hotbarItems.contains(itemStack.getItemId())) {
+                itemStacks.add(itemStack);
+            }
+        });
+        return itemContainer.canAddItemStacks(itemStacks);
     }
 }

--- a/src/main/java/com/clayfactoria/codecs/task/HarvestTaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/HarvestTaskExecutor.java
@@ -20,113 +20,114 @@ import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.npc.entities.NPCEntity;
-import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class HarvestTaskExecutor extends AreaTaskExecutor {
 
-  @Override
-  public boolean canPerformTask(Ref<EntityStore> entityRef) {
-    Store<EntityStore> store = entityRef.getStore();
-    JobComponent jobComponent = store.getComponent(entityRef, JobComponent.getComponentType());
-    assert jobComponent != null;
-    Job job = jobComponent.getCurrentJob();
-    assert job != null;
-    NPCEntity npc = TaskHelper.getNPCEntity(entityRef);
-    World world = npc.getWorld();
-    assert world != null;
+    @Override
+    public boolean canPerformTask(Ref<EntityStore> ref) {
+        Store<EntityStore> store = ref.getStore();
+        JobComponent jobComponent = store.getComponent(ref, JobComponent.getComponentType());
+        assert jobComponent != null;
+        Job job = jobComponent.getCurrentJob();
+        assert job != null;
+        NPCEntity npc = TaskHelper.getNPCEntity(ref);
+        World world = npc.getWorld();
+        assert world != null;
 
-    // Check if we can still do the task at this position
-    if (!canDoTaskHere(job.getLocation(), world)) {
-      return false;
+        // Check if we can still do the task at this position
+        if (!canDoTaskHere(job.getLocation(), world)) {
+            return false;
+        }
+
+        // Check that it doesn't have any other items than the sickle in its inventory.
+        CombinedItemContainer inventory = InventoryComponent.getCombined(store, ref,
+            InventoryComponent.EVERYTHING);
+        AtomicBoolean otherItemsFound = new AtomicBoolean(false);
+        inventory.forEach((_, itemStack) -> {
+            if (itemStack != null && !itemStack.getItemId().contains("Sickle")) {
+                otherItemsFound.set(true);
+            }
+        });
+
+        return !otherItemsFound.get();
     }
 
-    // Check that it doesn't have any other items than the sickle in its inventory.
-    CombinedItemContainer inventory = InventoryComponent.getCombined(store, entityRef,
-        InventoryComponent.EVERYTHING);
-    AtomicBoolean otherItemsFound = new AtomicBoolean(false);
-    inventory.forEach((_, itemStack) -> {
-      if (itemStack != null && !itemStack.getItemId().contains("Sickle")) {
-        otherItemsFound.set(true);
-      }
-    });
+    @Override
+    public boolean execute(Ref<EntityStore> entityRef) {
+        NPCEntity entity = TaskHelper.getNPCEntity(entityRef);
+        JobComponent job =
+            entityRef.getStore().getComponent(entityRef, JobComponent.getComponentType());
+        World world = entity.getWorld();
+        assert job != null;
+        assert job.getCurrentJob() != null;
+        assert world != null;
 
-    return !otherItemsFound.get();
-  }
+        Vector3i location = job.getCurrentJob().getLocation();
+        BlockType type = world.getBlockType(location.x, location.y, location.z);
+        assert type != null;
 
-  @Override
-  public boolean execute(Ref<EntityStore> entityRef) {
-    NPCEntity entity = TaskHelper.getNPCEntity(entityRef);
-    JobComponent job =
-        entityRef.getStore().getComponent(entityRef, JobComponent.getComponentType());
-    World world = entity.getWorld();
-    assert job != null;
-    assert job.getCurrentJob() != null;
-    assert world != null;
+        FarmingUtil.harvest(
+            world,
+            entityRef.getStore(),
+            entityRef,
+            type,
+            world.getBlockRotationIndex(location.x, location.y, location.z),
+            location);
 
-    Vector3i location = job.getCurrentJob().getLocation();
-    BlockType type = world.getBlockType(location.x, location.y, location.z);
-    assert type != null;
-
-    FarmingUtil.harvest(
-        world,
-        entityRef.getStore(),
-        entityRef,
-        type,
-        world.getBlockRotationIndex(location.x, location.y, location.z),
-        location);
-
-    InventoryComponent.Hotbar hotbar = entityRef.getStore()
-        .getComponent(entityRef, InventoryComponent.Hotbar.getComponentType());
-    assert hotbar != null;
-    hotbar.setActiveSlot((byte) (hotbar.getActiveSlot() + 1));
+        InventoryComponent.Hotbar hotbar = entityRef.getStore()
+            .getComponent(entityRef, InventoryComponent.Hotbar.getComponentType());
+        assert hotbar != null;
+        hotbar.setActiveSlot((byte) (hotbar.getActiveSlot() + 1));
 //    giveDrops(entityRef, type);
-    return true;
-  }
+        return true;
+    }
 
-  private void giveDrops(
-      @Nonnull Ref<EntityStore> ref,
-      @Nonnull BlockType blockType
-  ) {
-    Store<EntityStore> store = ref.getStore();
-    assert blockType.getGathering() != null;
-    HarvestingDropType harvestingDropType = blockType.getGathering().getHarvest();
-    String itemId = harvestingDropType.getItemId();
-    String dropListId = harvestingDropType.getDropListId();
+    private void giveDrops(
+        @Nonnull Ref<EntityStore> ref,
+        @Nonnull BlockType blockType
+    ) {
+        Store<EntityStore> store = ref.getStore();
+        assert blockType.getGathering() != null;
+        HarvestingDropType harvestingDropType = blockType.getGathering().getHarvest();
+        String itemId = harvestingDropType.getItemId();
+        String dropListId = harvestingDropType.getDropListId();
 
-    for (ItemStack itemStack : BlockHarvestUtils.getDrops(blockType, 1, itemId, dropListId)) {
-      CombinedItemContainer hotbarFirstCombinedItemContainer = InventoryComponent.getCombined(store,
-          ref, InventoryComponent.HOTBAR_FIRST);
-      SimpleItemContainer.addOrDropItemStack(store, ref, hotbarFirstCombinedItemContainer,
-          itemStack);
+        for (ItemStack itemStack : BlockHarvestUtils.getDrops(blockType, 1, itemId, dropListId)) {
+            CombinedItemContainer hotbarFirstCombinedItemContainer = InventoryComponent.getCombined(store,
+                ref, InventoryComponent.HOTBAR_FIRST);
+            SimpleItemContainer.addOrDropItemStack(store, ref, hotbarFirstCombinedItemContainer,
+                itemStack);
+        }
     }
-  }
 
-  @Override
-  protected boolean canDoTaskHere(Vector3i pos, World world) {
-    if (pos == null) {
-      return false;
+    @Override
+    protected boolean canDoTaskHere(Vector3i pos, World world) {
+        if (pos == null) {
+            return false;
+        }
+        Holder<ChunkStore> blockHolder = world.getBlockComponentHolder(pos.x, pos.y - 1, pos.z);
+        if (blockHolder == null) {
+            return false;
+        }
+        TilledSoilBlock tilledSoilBlock = blockHolder.getComponent(TilledSoilBlock.getComponentType());
+        if (tilledSoilBlock == null) {
+            return false;
+        }
+        if (!tilledSoilBlock.isPlanted()) {
+            return false;
+        }
+        BlockType type = world.getBlockType(pos.x, pos.y, pos.z);
+        if (type == null) {
+            return false;
+        }
+        return type.getId().endsWith("_StageFinal");
     }
-    Holder<ChunkStore> blockHolder = world.getBlockComponentHolder(pos.x, pos.y - 1, pos.z);
-    if (blockHolder == null) {
-      return false;
-    }
-    TilledSoilBlock tilledSoilBlock = blockHolder.getComponent(TilledSoilBlock.getComponentType());
-    if (tilledSoilBlock == null) {
-      return false;
-    }
-    if (!tilledSoilBlock.isPlanted()) {
-      return false;
-    }
-    BlockType type = world.getBlockType(pos.x, pos.y, pos.z);
-    if (type == null) {
-      return false;
-    }
-    return type.getId().endsWith("_StageFinal");
-  }
 
-  @Override
-  protected boolean shouldSearchLocationsAboveBoundingBox() {
-    return true;
-  }
+    @Override
+    protected boolean shouldSearchLocationsAboveBoundingBox() {
+        return true;
+    }
 }

--- a/src/main/java/com/clayfactoria/codecs/task/PositionTaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/PositionTaskExecutor.java
@@ -4,22 +4,23 @@ import com.clayfactoria.components.JobComponent;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+
 import java.util.Objects;
 
 public class PositionTaskExecutor extends PointTaskExecutor {
 
-  @Override
-  public boolean canPerformTask(Ref<EntityStore> entityRef) {
-    return true;
-  }
+    @Override
+    public boolean canPerformTask(Ref<EntityStore> ref) {
+        return true;
+    }
 
-  @Override
-  public boolean execute(Ref<EntityStore> entityRef) {
-    Store<EntityStore> store = entityRef.getStore();
-    JobComponent jobComponent = Objects.requireNonNull(
-        store.getComponent(entityRef, JobComponent.getComponentType()));
-    jobComponent.setComplete(true);
-    return true;
-  }
+    @Override
+    public boolean execute(Ref<EntityStore> entityRef) {
+        Store<EntityStore> store = entityRef.getStore();
+        JobComponent jobComponent = Objects.requireNonNull(
+            store.getComponent(entityRef, JobComponent.getComponentType()));
+        jobComponent.setComplete(true);
+        return true;
+    }
 
 }

--- a/src/main/java/com/clayfactoria/codecs/task/TakeTaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/TakeTaskExecutor.java
@@ -1,15 +1,10 @@
 package com.clayfactoria.codecs.task;
 
-import static com.clayfactoria.utils.TaskHelper.getHeldItemstack;
-import static com.clayfactoria.utils.TaskHelper.getNPCEntity;
-
 import com.clayfactoria.codecs.Job;
-import com.clayfactoria.codecs.Task;
 import com.clayfactoria.components.JobComponent;
 import com.clayfactoria.utils.ContainerSlot;
 import com.clayfactoria.utils.TaskHelper;
 import com.hypixel.hytale.component.Component;
-import com.hypixel.hytale.component.ComponentType;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
@@ -17,50 +12,47 @@ import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
 import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.npc.entities.NPCEntity;
+
 import java.util.Objects;
+
+import static com.clayfactoria.utils.TaskHelper.getHeldItemstack;
+import static com.clayfactoria.utils.TaskHelper.getNPCEntity;
 
 public class TakeTaskExecutor extends PointTaskExecutor {
 
-  @Override
-  public boolean canPerformTask(Ref<EntityStore> entityRef) {
-    Store<EntityStore> store = entityRef.getStore();
+    @Override
+    public boolean canPerformTask(Ref<EntityStore> ref) {
+        Store<EntityStore> store = ref.getStore();
+        Component<ChunkStore> blockEntity = TaskHelper.getBlockEntity(ref);
+        if (blockEntity == null) {
+            return false;
+        }
 
-    ComponentType<EntityStore, NPCEntity> component = NPCEntity.getComponentType();
-    Objects.requireNonNull(component, "NPC Entity Component Type was null");
+        ItemStack heldItemStack = getHeldItemstack(store, ref);
 
-    NPCEntity npcEntity = store.getComponent(entityRef, component);
-    Objects.requireNonNull(npcEntity, "NPC Entity was null");
+        ItemContainer container =
+            TaskHelper.getItemContainerFromComponent(blockEntity, ContainerSlot.Output);
+        Objects.requireNonNull(container, "Unexpected null ItemContainer");
 
-    Component<ChunkStore> nearbyPOI = TaskHelper.findNearbyPOI(npcEntity, Task.DEPOSIT);
-    if (nearbyPOI == null) {
-      return false;
+        // There must be items available to be taken, and there must be space in hands
+        return heldItemStack == null && !container.isEmpty();
     }
 
-    ItemStack heldItemStack = getHeldItemstack(store, entityRef);
+    @Override
+    public boolean execute(Ref<EntityStore> entityRef) {
+        NPCEntity npcEntity = getNPCEntity(entityRef);
+        Store<EntityStore> store = entityRef.getStore();
+        JobComponent jobComponent = Objects.requireNonNull(
+            store.getComponent(entityRef, JobComponent.getComponentType()));
+        Job currentJob = Objects.requireNonNull(jobComponent.getCurrentJob());
 
-    ItemContainer container =
-        TaskHelper.getItemContainerFromComponent(nearbyPOI, ContainerSlot.Output);
-    Objects.requireNonNull(container, "Unexpected null ItemContainer");
+        ItemContainer itemContainer = TaskHelper.getItemContainerAtPos(
+            Objects.requireNonNull(npcEntity.getWorld()),
+            currentJob.getLocation(), ContainerSlot.Output);
+        Objects.requireNonNull(itemContainer);
 
-    // There must be items available to be taken, and there must be space in hands
-    return heldItemStack == null && !container.isEmpty();
-  }
-
-  @Override
-  public boolean execute(Ref<EntityStore> entityRef) {
-    NPCEntity npcEntity = getNPCEntity(entityRef);
-    Store<EntityStore> store = entityRef.getStore();
-    JobComponent jobComponent = Objects.requireNonNull(
-        store.getComponent(entityRef, JobComponent.getComponentType()));
-    Job currentJob = Objects.requireNonNull(jobComponent.getCurrentJob());
-
-    ItemContainer itemContainer = TaskHelper.getItemContainerAtPos(
-        Objects.requireNonNull(npcEntity.getWorld()),
-        currentJob.getLocation(), ContainerSlot.Output);
-    Objects.requireNonNull(itemContainer);
-
-    ItemContainer npcInventory = TaskHelper.getNPCInventory(npcEntity, store);
-    return TaskHelper.transferItem(itemContainer, npcInventory, 1);
-  }
+        ItemContainer npcInventory = TaskHelper.getNPCInventory(npcEntity, store);
+        return TaskHelper.transferItem(itemContainer, npcInventory, 1);
+    }
 
 }

--- a/src/main/java/com/clayfactoria/codecs/task/TaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/TaskExecutor.java
@@ -9,11 +9,11 @@ import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 
 public interface TaskExecutor {
 
-  boolean canPerformTask(Ref<EntityStore> entityRef);
+    boolean canPerformTask(Ref<EntityStore> ref);
 
-  boolean execute(Ref<EntityStore> entityRef);
+    boolean execute(Ref<EntityStore> entityRef);
 
-  void checkBounds(Box bounds) throws IllegalArgumentException;
+    void checkBounds(Box bounds) throws IllegalArgumentException;
 
-  Vector3d findNextWalkLocation(Job job, World world, Vector3d from);
+    Vector3d findNextWalkLocation(Job job, World world, Vector3d from);
 }

--- a/src/main/java/com/clayfactoria/codecs/task/WorkTaskExecutor.java
+++ b/src/main/java/com/clayfactoria/codecs/task/WorkTaskExecutor.java
@@ -1,13 +1,11 @@
 package com.clayfactoria.codecs.task;
 
 import com.clayfactoria.codecs.Job;
-import com.clayfactoria.codecs.Task;
 import com.clayfactoria.components.JobComponent;
 import com.clayfactoria.utils.TaskHelper;
 import com.hypixel.hytale.builtin.crafting.component.BenchBlock;
 import com.hypixel.hytale.builtin.crafting.component.ProcessingBenchBlock;
 import com.hypixel.hytale.component.Component;
-import com.hypixel.hytale.component.ComponentType;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.math.vector.Vector3i;
@@ -23,17 +21,9 @@ import static com.clayfactoria.utils.TaskHelper.getNPCEntity;
 public class WorkTaskExecutor extends PointTaskExecutor {
 
     @Override
-    public boolean canPerformTask(Ref<EntityStore> entityRef) {
-        Store<EntityStore> store = entityRef.getStore();
-
-        ComponentType<EntityStore, NPCEntity> component = NPCEntity.getComponentType();
-        Objects.requireNonNull(component, "NPC Entity Component Type was null");
-
-        NPCEntity npcEntity = store.getComponent(entityRef, component);
-        Objects.requireNonNull(npcEntity, "NPC Entity was null");
-
-        Component<ChunkStore> nearbyPOI = TaskHelper.findNearbyPOI(npcEntity, Task.WORK);
-        return nearbyPOI != null;
+    public boolean canPerformTask(Ref<EntityStore> ref) {
+        Component<ChunkStore> blockEntity = TaskHelper.getBlockEntity(ref);
+        return blockEntity != null;
     }
 
     @Override

--- a/src/main/java/com/clayfactoria/utils/TaskHelper.java
+++ b/src/main/java/com/clayfactoria/utils/TaskHelper.java
@@ -1,18 +1,12 @@
 package com.clayfactoria.utils;
 
-import com.clayfactoria.codecs.Task;
+import com.clayfactoria.codecs.Job;
+import com.clayfactoria.components.JobComponent;
 import com.hypixel.hytale.builtin.crafting.component.ProcessingBenchBlock;
-import com.hypixel.hytale.component.Component;
-import com.hypixel.hytale.component.ComponentType;
-import com.hypixel.hytale.component.Holder;
-import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.*;
 import com.hypixel.hytale.logger.HytaleLogger;
 import com.hypixel.hytale.math.util.ChunkUtil;
-import com.hypixel.hytale.math.vector.Vector3d;
 import com.hypixel.hytale.math.vector.Vector3i;
-import com.hypixel.hytale.protocol.Direction;
-import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockType;
 import com.hypixel.hytale.server.core.inventory.InventoryComponent;
 import com.hypixel.hytale.server.core.inventory.InventoryComponent.Hotbar;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
@@ -25,14 +19,14 @@ import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.npc.entities.NPCEntity;
 import com.hypixel.hytale.server.npc.role.Role;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public final class TaskHelper {
 
@@ -53,38 +47,44 @@ public final class TaskHelper {
     }
 
     @Nullable
-    public static Component<ChunkStore> findNearbyPOI(NPCEntity npcEntity, Task task) {
+    public static Component<ChunkStore> getBlockEntity(Ref<EntityStore> ref) {
+        Store<EntityStore> store = ref.getStore();
+        NPCEntity npcEntity = store.getComponent(ref, Objects.requireNonNull(NPCEntity.getComponentType()));
+        Objects.requireNonNull(npcEntity);
+        JobComponent jobComponent = store.getComponent(ref, JobComponent.getComponentType());
+        assert jobComponent != null;
         World world = Objects.requireNonNull(npcEntity.getWorld());
-        Vector3i pos = npcEntity.getOldPosition().toVector3i();
-        List<Vector3i> shuffled = getAdjacentDirections();
-        for (Vector3i dir : shuffled) {
-            Vector3i baseBlock = BlockUtils.getBaseBlock(new Vector3i(pos.add(dir)), world);
-            Holder<ChunkStore> holder = world.getBlockComponentHolder(baseBlock.x, baseBlock.y,
-                baseBlock.z);
-            if (holder == null) {
-                continue;
-            }
-            ItemContainerBlock itemContainerBlock = holder.getComponent(
-                ItemContainerBlock.getComponentType());
-            ProcessingBenchBlock processingBenchBlock = holder.getComponent(
-                ProcessingBenchBlock.getComponentType());
-
-            switch (task) {
-                case POSITION:
-                    return null;
-                case TAKE, DEPOSIT: // Find a container
-                    if (itemContainerBlock != null) {
-                        return itemContainerBlock;
-                    }
-                    if (processingBenchBlock != null) {
-                        return processingBenchBlock;
-                    }
-                case WORK: // Find a processing bench
-                    if (processingBenchBlock != null) {
-                        return processingBenchBlock;
-                    }
-            }
+        Job job = jobComponent.getCurrentJob();
+        if (job == null) {
+            return null;
         }
+        Vector3i pos = job.getLocation();
+        Vector3i baseBlock = BlockUtils.getBaseBlock(pos, world);
+        Holder<ChunkStore> holder = world.getBlockComponentHolder(baseBlock.x, baseBlock.y,
+            baseBlock.z);
+        if (holder == null) return null;
+
+        ItemContainerBlock itemContainerBlock = holder.getComponent(
+            ItemContainerBlock.getComponentType());
+        ProcessingBenchBlock processingBenchBlock = holder.getComponent(
+            ProcessingBenchBlock.getComponentType());
+
+        switch (job.getTask()) {
+            case POSITION:
+                return null;
+            case TAKE, DEPOSIT: // Find a container
+                if (itemContainerBlock != null) {
+                    return itemContainerBlock;
+                }
+                if (processingBenchBlock != null) {
+                    return processingBenchBlock;
+                }
+            case WORK: // Find a processing bench
+                if (processingBenchBlock != null) {
+                    return processingBenchBlock;
+                }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
When checking if the task could be started, NPCs would scan surrounding blocks to try to find the block. This was unnecessary as we have the location for the job on the job codec, so we can skip straight to looking at that block. The scan around was leading to the wrong block being looked at and determining that a nearby chest had items in it so it thought it could take from the furnace (the true target). So it tried to run the action but obviously couldn't take from the empty furnace.

Closes #98

---

Related to ticket #98, hence being on this branch. There was already a check that the container isn't full, but the actual issue was the it was only checking if it could deposit the currently held item, not all of the items that it wanted to deposit, so it would run the deposit task and only manage to deposit some of the items.

Closes #108
